### PR TITLE
Adding BasisTranslator support for decompose_toffoli = 2

### DIFF
--- a/qcopt/ansatz/gate_decomp.py
+++ b/qcopt/ansatz/gate_decomp.py
@@ -1,0 +1,26 @@
+"""
+03/29/2022 - Nicholas Allen
+
+Auxiliary file for extending the StandardEquivalenceLibrary to aid when decompose_toffoli = 2.
+"""
+import warnings
+from qiskit.qasm import pi
+from qiskit.circuit import EquivalenceLibrary, Parameter, QuantumCircuit, QuantumRegister
+
+from qiskit.circuit.library.standard_gates import (
+    UGate,
+    U3Gate,
+)
+from qiskit.circuit.equivalence_library import StandardEquivalenceLibrary
+
+_cel = CustomEquivalenceLibrary = StandardEquivalenceLibrary
+
+# U gate
+
+q = QuantumRegister(1, 'q')
+theta = Parameter('theta')
+phi = Parameter('phi')
+lam = Parameter('lam')
+u_to_u3 = QuantumCircuit(q)
+u_to_u3.append(U3Gate(theta, phi, lam), [0])
+_cel.add_equivalence(UGate(theta, phi, lam), u_to_u3)

--- a/qcopt/ansatz/qao_ansatz.py
+++ b/qcopt/ansatz/qao_ansatz.py
@@ -22,7 +22,7 @@ from qiskit.transpiler.passes import BasisTranslator
 from qiskit.transpiler import PassManager
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 
-from gate_decomp import CustomEquivalenceLibrary
+from qcopt.ansatz.gate_decomp import CustomEquivalenceLibrary
 
 import qcopt
 

--- a/qcopt/ansatz/qao_ansatz.py
+++ b/qcopt/ansatz/qao_ansatz.py
@@ -15,9 +15,14 @@ import networkx as nx
 import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit import ControlledGate
+from qiskit.circuit import EquivalenceLibrary
 from qiskit.circuit.library.standard_gates import RXGate
 from qiskit.transpiler.passes import Unroller
+from qiskit.transpiler.passes import BasisTranslator
 from qiskit.transpiler import PassManager
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+
+from gate_decomp import CustomEquivalenceLibrary
 
 import qcopt
 
@@ -147,10 +152,14 @@ def gen_qaoa(
             qaoa_circ.barrier()
 
     if decompose_toffoli > 1:
-        # basis_gates = ['x', 'cx', 'barrier', 'crx', 'tdg', 't', 'rz', 'h']
-        basis_gates = ["u1", "u2", "u3", "cx"]
-        pass_ = Unroller(basis_gates)
+        basis_gates_u = ['u1', 'u2', 'u3', 'cx', 'u']
+        basis_gates = ['u1', 'u2', 'u3', 'cx']
+        pass_ = Unroller(basis_gates_u)
         pm = PassManager(pass_)
         qaoa_circ = pm.run(qaoa_circ)
+        
+        bt_pass = BasisTranslator(CustomEquivalenceLibrary, basis_gates)
+        dag_out = bt_pass.run(circuit_to_dag(qaoa_circ))
+        qaoa_circ = dag_to_circuit(dag_out)
 
     return qaoa_circ


### PR DESCRIPTION
Adds `BasisTranslator` support to fix issue #2, by using an `Unroller` pass followed by an extension of the `StandardEquivalenceLibrary` that includes an equivalence from `UGate` to `U3Gate`, included in `gate_decomp.py` for potential future gate equivalences.